### PR TITLE
refactor action retrieval test

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,6 @@
-cognitive-complexity-threshold = 4
-too-many-arguments-threshold = 3
+cognitive-complexity-threshold = 3
 too-many-lines-threshold = 14
+excessive-nesting-threshold = 3
+too-many-arguments-threshold = 3
+max-fn-params-bools = 1
+max-struct-bools = 1

--- a/src/action_queue.rs
+++ b/src/action_queue.rs
@@ -27,16 +27,23 @@ mod tests {
     #[test]
     fn actions_are_retrieved_in_first_in_first_out_order() {
         let mut action_queue = ActionQueue::new();
-        let actions = vec![""];
+        let actions = vec!["1", "2", "3"];
 
-        for action in &actions {
-            action_queue.add_action((*action).to_owned());
-        }
+        add_actions_to_queue(&actions, &mut action_queue);
+        let retrieved_actions = get_actions_from_queue(action_queue);
+
+        assert_eq!(actions, retrieved_actions);
+    }
+    fn add_actions_to_queue(actions: &[&str], queue: &mut ActionQueue) {
+        actions
+            .iter()
+            .for_each(|action| queue.add_action((*action).to_owned()));
+    }
+    fn get_actions_from_queue(mut action_queue: ActionQueue) -> Vec<Action> {
         let mut retrieved_actions = Vec::<Action>::new();
         while let Some(action) = action_queue.get_next_action() {
             retrieved_actions.push(action);
         }
-
-        assert_eq!(actions, retrieved_actions);
+        retrieved_actions
     }
 }


### PR DESCRIPTION
This pull request includes several changes to the `clippy.toml` configuration file and improvements to the test functions in `src/action_queue.rs`. The most important changes are as follows:

### Configuration Updates:

* [`clippy.toml`](diffhunk://#diff-f3dbfb2563c3490394f44c26b51837018e79a79e75fd31e89b19e943a38317eaL1-R6): Adjusted the `cognitive-complexity-threshold` from 4 to 3, added `excessive-nesting-threshold` set to 3, and introduced limits for boolean parameters in functions and structs.

### Test Improvements:

* [`src/action_queue.rs`](diffhunk://#diff-98dfbb2b2f24e84481d36da447bc5718fb1436620709b315d9cb0359e6e6b2a4L30-R47): Refactored the `actions_are_retrieved_in_first_in_first_out_order` test to use helper functions `add_actions_to_queue` and `get_actions_from_queue`, improving code readability and maintainability.